### PR TITLE
Fix most Z-buffering faults in openscad preview

### DIFF
--- a/src/girl/girl_grid.scad
+++ b/src/girl/girl_grid.scad
@@ -110,7 +110,7 @@ module girl_grid_section(x_p, y_p, x_n, y_n) {
 			_girl_grid_slots();
 		}
 			
-		linear_extrude(grid_height+100)
+		linear_extrude(grid_height+100, convexity=4)
 		offset( lock_depth/2)
 		offset(-lock_depth/2)
 		square([grid_size,grid_size],center=true);

--- a/src/girl/girl_lock.scad
+++ b/src/girl/girl_lock.scad
@@ -18,7 +18,7 @@ module girl_lock() {
 
 module girl_slot() {
 	$fn=12;
-	linear_extrude(lock_height+0.4, center=true)
+	linear_extrude(lock_height+0.4, center=true, convexity=4)
 	mirror_copy([0,1])
 	mirror_copy([1,0])
 	_girl_slot_part();


### PR DESCRIPTION
Specifying the [convexity=](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#convexity) of a linear extrude fixes problems when previewing interactively. I found that most of the obvious rendering errors were fixed with these two uses of convexity=, though I didn't read the code in depth enough to defend my specific decisions.